### PR TITLE
[WIP] Initial pass of converting to Record/Tuple naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,6 @@ Structural sharing is a technique used to limit the memory footprint of immutabl
 
 #### Value type
 
-In this proposal it defines any of those: `boolean`, `number`, `symbol`, `string`, `undefined`, `null`, `record` and `tuple`.
+In this proposal it defines any of those: `boolean`, `number`, `symbol`, `string`, `undefined`, `null`, `Record` and `Tuple`.
 
 Value types can only contain other value types: because of that, two value types with the same contents are strictly equal.


### PR DESCRIPTION
[WIP]! I likely missed something / broke something, so this needs another pass.

This is the first pass of renaming "const values types" -> "Record" and "Tuple". I attempted to replace all usage/reference to the new types as objects/constant value types with their proper names. This required slightly changing the wording in some places in order to be less ambiguous. 

So far, I have left the `Syntax` section unchanged, and they still refer `const`. What do we want to do here?