### PR TITLE
"record keys are not ordered

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ assert(Object(#{ a: 1 }) !== Object(#{ a: 1 }));
 assert(Object(#[1, 2]) !== Object(#[1, 2]));
 ```
 
-Insertion order does not affect equality of records:
+Insertion order of record keys does not affect equality of records:
 
 ```js
 assert(#{ a: 1, b: 2 } === #{ b: 2, a: 1 });


### PR DESCRIPTION
Update our explainer to reflect that record keys are not ordered

We determined that having a notion of equality for records
that is dependent on insertion order would have poor
ergonomics and would not buy us any performance gain.


This PR does *not* resolve the question of what the sort function will be for the return value of `Record.keys`. @rickbutton is working on that.